### PR TITLE
Add stablevoting.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ This list collects high-quality code libraries, software tools and web applicati
 
 ### Multi-user web tools (online polls)
 
-- [Pnyx](https://pnyx.dss.in.tum.de/): web tool for  preference aggregation (possible output: single winner, lotteries, rankings)
+- [Pnyx](https://pnyx.dss.in.tum.de/): web tool for preference aggregation (possible output: single winner, lotteries, rankings)
 - [Whale](https://whale5.noiraudes.net/): Which Alternative is Elected?
+- [Stable Voting](https://stablevoting.org/): online polls using the "Stable Voting" Condorcet method
  
 
 ## Data


### PR DESCRIPTION
Tool by Wesley H. Holliday and Eric Pacuit.

Why include?

* modern code base, this is how future online poll tools should be implemented imho
* coded and maintained by senior academics, therefore expected longevity

Why not include?

* just 1 voting method which does not (yet) have broad support in any community